### PR TITLE
Bump versions for Silk.NET and StbImageWriteSharp

### DIFF
--- a/samples/NvgExample/NvgExample.csproj
+++ b/samples/NvgExample/NvgExample.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Silk.NET.Maths" Version="2.8.0" />
+    <PackageReference Include="Silk.NET.Maths" Version="2.17.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/OpenGL Example/OpenGL Example.csproj
+++ b/samples/OpenGL Example/OpenGL Example.csproj
@@ -20,10 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Silk.NET.Windowing" Version="2.8.0" />
-    <PackageReference Include="Silk.NET.Input" Version="2.8.0" />
-    <PackageReference Include="Silk.NET.OpenGL" Version="2.8.0" />
-    <PackageReference Include="StbImageWriteSharp" Version="1.13.5" />
+    <PackageReference Include="Silk.NET.Windowing" Version="2.17.1" />
+    <PackageReference Include="Silk.NET.Input" Version="2.17.1" />
+    <PackageReference Include="Silk.NET.OpenGL" Version="2.17.1" />
+    <PackageReference Include="StbImageWriteSharp" Version="1.16.7" />
   </ItemGroup>
 
 </Project>

--- a/samples/Vulkan Example/Vulkan Example.csproj
+++ b/samples/Vulkan Example/Vulkan Example.csproj
@@ -21,12 +21,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Silk.NET.Windowing" Version="2.8.0" />
-    <PackageReference Include="Silk.NET.Input" Version="2.8.0" />
-    <PackageReference Include="Silk.NET.Vulkan" Version="2.8.0" />
-    <PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.8.0" />
-    <PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.8.0" />
-    <PackageReference Include="StbImageWriteSharp" Version="1.13.5" />
+    <PackageReference Include="Silk.NET.Windowing" Version="2.17.1" />
+    <PackageReference Include="Silk.NET.Input" Version="2.17.1" />
+    <PackageReference Include="Silk.NET.Vulkan" Version="2.17.1" />
+    <PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.17.1" />
+    <PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.17.1" />
+    <PackageReference Include="StbImageWriteSharp" Version="1.16.7" />
   </ItemGroup>
 
 </Project>

--- a/src/SilkyNvg.Common/SilkyNvg.Common.csproj
+++ b/src/SilkyNvg.Common/SilkyNvg.Common.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Silk.NET" Version="2.8.0" />
+    <PackageReference Include="Silk.NET" Version="2.17.1" />
   </ItemGroup>
 
 </Project>

--- a/src/rendering/SilkyNvg.Rendering.OpenGL/Calls/FillCall.cs
+++ b/src/rendering/SilkyNvg.Rendering.OpenGL/Calls/FillCall.cs
@@ -22,8 +22,8 @@ namespace SilkyNvg.Rendering.OpenGL.Calls
             renderer.Shader.SetUniforms(uniformOffset, 0);
             renderer.CheckError("fill simple");
 
-            gl.StencilOpSeparate(StencilFaceDirection.Front, StencilOp.Keep, StencilOp.Keep, StencilOp.IncrWrap);
-            gl.StencilOpSeparate(StencilFaceDirection.Back, StencilOp.Keep, StencilOp.Keep, StencilOp.DecrWrap);
+            gl.StencilOpSeparate(TriangleFace.Front, StencilOp.Keep, StencilOp.Keep, StencilOp.IncrWrap);
+            gl.StencilOpSeparate(TriangleFace.Back, StencilOp.Keep, StencilOp.Keep, StencilOp.DecrWrap);
             gl.Disable(EnableCap.CullFace);
             foreach (Path path in paths)
             {

--- a/src/rendering/SilkyNvg.Rendering.OpenGL/OpenGLRenderer.cs
+++ b/src/rendering/SilkyNvg.Rendering.OpenGL/OpenGLRenderer.cs
@@ -172,7 +172,7 @@ namespace SilkyNvg.Rendering.OpenGL
                 Shader.Start();
 
                 Gl.Enable(EnableCap.CullFace);
-                Gl.CullFace(CullFaceMode.Back);
+                Gl.CullFace(TriangleFace.Back);
                 Gl.FrontFace(FrontFaceDirection.Ccw);
                 Gl.Enable(EnableCap.Blend);
                 Gl.Disable(EnableCap.DepthTest);

--- a/src/rendering/SilkyNvg.Rendering.OpenGL/SilkyNvg.Rendering.OpenGL.csproj
+++ b/src/rendering/SilkyNvg.Rendering.OpenGL/SilkyNvg.Rendering.OpenGL.csproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Silk.NET.Maths" Version="2.8.0" />
-    <PackageReference Include="Silk.NET.OpenGL" Version="2.8.0" />
+    <PackageReference Include="Silk.NET.Maths" Version="2.17.1" />
+    <PackageReference Include="Silk.NET.OpenGL" Version="2.17.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/rendering/SilkyNvg.Rendering.Vulkan/SilkyNvg.Rendering.Vulkan.csproj
+++ b/src/rendering/SilkyNvg.Rendering.Vulkan/SilkyNvg.Rendering.Vulkan.csproj
@@ -27,8 +27,8 @@ It has some issues and uses poor code style but has the basic functionallity.</D
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Silk.NET.Maths" Version="2.8.0" />
-    <PackageReference Include="Silk.NET.Vulkan" Version="2.8.0" />
+    <PackageReference Include="Silk.NET.Maths" Version="2.17.1" />
+    <PackageReference Include="Silk.NET.Vulkan" Version="2.17.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/IncreasingFontSizeTest/IncreasingFontSizeTest.csproj
+++ b/tests/IncreasingFontSizeTest/IncreasingFontSizeTest.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <PackageReference Include="Silk.NET.Windowing" Version="2.8.0" />
-      <PackageReference Include="Silk.NET.Input" Version="2.8.0" />
-      <PackageReference Include="Silk.NET.OpenGL" Version="2.8.0" />
+      <PackageReference Include="Silk.NET.Windowing" Version="2.17.1" />
+      <PackageReference Include="Silk.NET.Input" Version="2.17.1" />
+      <PackageReference Include="Silk.NET.OpenGL" Version="2.17.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Bump Silk.NET to 2.17,1
- Bump StbImageWriteSharp to 1.16.7
- Fix compile time errors in SilkyNvg.Rendering.OpenGL.Calls.FillCall.Run and SilkyNvg.Rendering.OpenGL.OpenGLRenderer.Flush